### PR TITLE
Simplify post-install step

### DIFF
--- a/org.flycast.Flycast.yml
+++ b/org.flycast.Flycast.yml
@@ -4,6 +4,7 @@ runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 command: flycast
 rename-desktop-file: flycast.desktop
+rename-icon: flycast
 finish-args:
   - --device=all
   - --filesystem=host:ro
@@ -19,16 +20,7 @@ modules:
     builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=build
     post-install:
-      - install -Dm755 build/flycast /app/bin
-      - |-
-        for px in 16 32 64 128 256 512; do
-          install -Dm644 ../shell/apple/emulator-osx/emulator-osx/Images.xcassets/AppIcon.appiconset/Icon-$px.png /app/share/icons/hicolor/${px}x${px}/apps/org.flycast.Flycast.png
-        done
-      - desktop-file-install ../shell/linux/flycast.desktop --dir /app/share/applications
-      - sed -i 's/^Icon=flycast/Icon=org.flycast.Flycast/' /app/share/applications/flycast.desktop
-      - install -Dm644 ../shell/linux/org.flycast.Flycast.metainfo.xml /app/share/metainfo/org.flycast.Flycast.metainfo.xml
       - sed -i "s/date=.* v/date=\"$(git log -1 --format=%ci | awk '{print $1}')\" v/" /app/share/metainfo/org.flycast.Flycast.metainfo.xml
     sources:
       - type: git


### PR DESCRIPTION
The command `ninja install` puts the files in the right directory (`/app`) because Flycast has now an install target: https://github.com/flyinghead/flycast/pull/421
