### PR TITLE
README.md: install org.freedesktop.Platform/x86_64/21.08 to build locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `flatpak-builder` package is required.
 
 - Install the SDK
 
-`flatpak install org.freedesktop.Sdk/x86_64/21.08`
+`flatpak install org.freedesktop.Platform/x86_64/21.08 org.freedesktop.Sdk/x86_64/21.08`
 
 - Build Flycast
 


### PR DESCRIPTION
Without this, I had the following error when trying to build:
```
Failed to init: Unable to find runtime.org.freedesktop.Platform version 21.08
```